### PR TITLE
Cambiando el puerto default de python, de 8080 a 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `make server`
 
-Ir a `http://localhost:8080` para verlo.
+Ir a `http://localhost:8000` para verlo.
 
 ## Deploy:
 


### PR DESCRIPTION
El puerto default es el 8000  en vez del 8080 como dice en el README.md 
